### PR TITLE
Added isMounted check to setState call in asynchronous callback function

### DIFF
--- a/src/notification-item.js
+++ b/src/notification-item.js
@@ -133,9 +133,11 @@ var NotificationItem = React.createClass({
   _showNotification: function() {
     var self = this;
     setTimeout(function(){
-      self.setState({
-        visible: true,
-      });
+      if (self.isMounted()) {
+        self.setState({
+          visible: true,
+        });
+      }
     }, 50);
   },
 


### PR DESCRIPTION
At some scenarios, I got warning about setState call to unmounted component. Adding this check fixed the issue.