### PR TITLE
Updating dependencies to React v15

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ npm install react-notification-system
 
 ### Important
 
-For **React 0.14.x**, use version 0.2.x:
+For **React ^0.14.x** or **React ^15.x.x**, use version 0.2.x:
 
 ```
 npm install react-notification-system@0.2.x

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react": "0.14.x || ^15.0.0",
+    "react-dom": "0.14.x || ^15.0.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0",
-    "react-dom": "^0.14.0"
+    "react": "^15.0.0",
+    "react-dom": "^15.0.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",
@@ -69,9 +69,9 @@
     "mocha": "^2.3.3",
     "node-sass": "^3.3.3",
     "npm": "^3.3.6",
-    "react": "^0.14.0",
-    "react-addons-test-utils": "^0.14.0",
-    "react-dom": "^0.14.0",
+    "react": "^15.0.0",
+    "react-addons-test-utils": "^15.0.0",
+    "react-dom": "^15.0.0",
     "react-tools": "^0.13.2",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",


### PR DESCRIPTION
This updates react, react-dom, and react-addons-test-utils dependencies to 15.0.0.

It also changes line 21 in the README to indicate that 0.2.x works with both React 0.14.x and React 15.0.x.

No console warnings, and all tests pass:
![screen shot 2016-04-08 at 11 05 49 am](https://cloud.githubusercontent.com/assets/4145673/14388011/fb6c977e-fd79-11e5-83f8-eee86da0506a.png)
