### PR TITLE
Don't call setState after notification removed if component is unmounted

### DIFF
--- a/src/NotificationSystem.jsx
+++ b/src/NotificationSystem.jsx
@@ -74,7 +74,7 @@ var NotificationSystem = React.createClass({
       notification.onRemove(notification);
     }
 
-    if(this._isMounted) {
+    if (this._isMounted) {
       this.setState({ notifications: notifications });
     }
   },

--- a/src/NotificationSystem.jsx
+++ b/src/NotificationSystem.jsx
@@ -8,6 +8,8 @@ var NotificationSystem = React.createClass({
 
   uid: 3400,
 
+  _isMounted: false,
+
   _getStyles: {
     overrideStyle: {},
 
@@ -72,7 +74,9 @@ var NotificationSystem = React.createClass({
       notification.onRemove(notification);
     }
 
-    this.setState({ notifications: notifications });
+    if(this._isMounted) {
+      this.setState({ notifications: notifications });
+    }
   },
 
   getInitialState: function() {
@@ -164,6 +168,11 @@ var NotificationSystem = React.createClass({
 
   componentDidMount: function() {
     this._getStyles.setOverrideStyle(this.props.style);
+    this._isMounted = true;
+  },
+
+  componentWillUnmount: function() {
+    this._isMounted = false;
   },
 
   render: function() {


### PR DESCRIPTION
If a notification is configured with a redirect in the onRemove method (something like `onRemove: () => {this.context.router.push(...)}`), a warning will be logged in the browser on execution: (`warning.js:45 Warning: setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the NotificationSystem component.`)

I see this error came up before in #3 and #17 , so I took a similar approach with the fix here.