### PR TITLE
added: deleteNotification method which instantly removes notification…

### DIFF
--- a/src/NotificationSystem.jsx
+++ b/src/NotificationSystem.jsx
@@ -162,6 +162,20 @@ var NotificationSystem = React.createClass({
     });
   },
 
+  deleteNotification: function(notification) {
+    var self = this;
+    Object.keys(this.refs).forEach(function(container) {
+      if (container.indexOf('container') > -1) {
+        Object.keys(self.refs[container].refs).forEach(function(_notification) {
+          var uid = notification.uid ? notification.uid : notification;
+          if (_notification === 'notification-' + uid) {
+            self.refs[container].refs[_notification]._removeNotification();
+          }
+        });
+      }
+    });
+  },
+
   componentDidMount: function() {
     this._getStyles.setOverrideStyle(this.props.style);
   },

--- a/test/notification-system.test.js
+++ b/test/notification-system.test.js
@@ -164,6 +164,30 @@ describe('Notification Component', function() {
     done();
   });
 
+  it('should delete a notification using returned object', done => {
+    let notificationCreated = component.addNotification(defaultNotification);
+    let notification = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'notification');
+    expect(notification.length).toEqual(1);
+
+    component.deleteNotification(notificationCreated);
+    //clock.tick(1000);
+    let notificationDeleted = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'notification');
+    expect(notificationDeleted.length).toEqual(0);
+    done();
+  });
+
+  it('should delete a notification using uid', done => {
+    let notificationCreated = component.addNotification(defaultNotification);
+    let notification = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'notification');
+    expect(notification.length).toEqual(1);
+
+    component.deleteNotification(notificationCreated.uid);
+    //clock.tick(200);
+    let notificationDeleted = TestUtils.scryRenderedDOMComponentsWithClass(instance, 'notification');
+    expect(notificationDeleted.length).toEqual(0);
+    done();
+  });
+
   it('should dismiss notification on click', done => {
     component.addNotification(notificationObj);
     let notification = TestUtils.findRenderedDOMComponentWithClass(instance, 'notification');


### PR DESCRIPTION
…, rather than removeNotification() which applies animation. Useful when a loading and a success message follow each other in quick succession, as the loading notificaitons animation had not yet terminated, causing an odd slide in and down to occur