### PR TITLE
Blr/use classnames and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,28 @@
 
 > A complete and totally customizable component for notifications in React.
 
-_Initially built for [Eterpret](http://dev.eterpret.com) @ [Scalable Path](http://www.scalablepath.com)._
+_Initially built for [Eterpret](http://dev.eterpret.com) @ [Scalable Path](http://www.scalablepath.com).
 
 <a href="https://igorprado.github.io/react-notification-system/"><img width="728" src="example/src/images/screenshot.jpg" alt="Screenshot"></a>
 
 ## Installing
 
-For now this component is only available as CommonJS module. Install via NPM running:
+For now this component is only available as CommonJS module. Install via [npm](https://www.npmjs.com/) by running:
 
 ```
 npm install react-notification-system
+```
+
+Save it to the `dependencies` in your `package.json` via npm by running:
+
+```
+npm install --save react-notification-system
+```
+
+Alternatively, install via [Yarn](https://yarnpkg.com) and automatically save to the `dependencies` in your `package.json` by running:
+
+```
+yarn add react-notification-system
 ```
 
 ### Important
@@ -64,7 +76,7 @@ var MyComponent = React.createClass({
         <button onClick={this._addNotification}>Add notification</button>
         <NotificationSystem ref="notificationSystem" />
       </div>
-      );
+    );
   }
 });
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > A complete and totally customizable component for notifications in React.
 
-_Initially built for [Eterpret](http://dev.eterpret.com) @ [Scalable Path](http://www.scalablepath.com).
+_Initially built for [Eterpret](http://dev.eterpret.com) @ [Scalable Path](http://www.scalablepath.com)._
 
 <a href="https://igorprado.github.io/react-notification-system/"><img width="728" src="example/src/images/screenshot.jpg" alt="Screenshot"></a>
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/igorprado/react-notification-system",
   "dependencies": {
+    "classnames": "^2.2.5",
     "object-assign": "^4.0.1"
   },
   "peerDependencies": {

--- a/src/NotificationItem.jsx
+++ b/src/NotificationItem.jsx
@@ -3,6 +3,7 @@ var ReactDOM = require('react-dom');
 var Constants = require('./constants');
 var Helpers = require('./helpers');
 var merge = require('object-assign');
+var classnames = require('classnames');
 
 /* From Modernizr */
 var whichTransitionEvent = function() {
@@ -240,7 +241,6 @@ var NotificationItem = React.createClass({
 
   render: function() {
     var notification = this.props.notification;
-    var className = 'notification notification-' + notification.level;
     var notificationStyle = merge({}, this._styles.notification);
     var cssByPos = this._getCssPropertyByPosition();
     var dismiss = null;
@@ -248,15 +248,15 @@ var NotificationItem = React.createClass({
     var title = null;
     var message = null;
 
-    if (this.state.visible) {
-      className += ' notification-visible';
-    } else {
-      className += ' notification-hidden';
-    }
-
-    if (!notification.dismissible) {
-      className += ' notification-not-dismissible';
-    }
+    var className = classnames(
+      'notification',
+      'notification-' + notification.level,
+      {
+        'notification-visible': this.state.visible,
+        'notification-hidden': !this.state.visible,
+        'notification-not-dismissible': !notification.dismissible
+      }
+    );
 
     if (this.props.getStyles.overrideStyle) {
       if (!this.state.visible && !this.state.removed) {


### PR DESCRIPTION
@igorprado Please review. This PR:
- Adds the lightweight [classnames](https://github.com/JedWatson/classnames) library to simplify the construction of the `className` prop being passed to the `NotificationItem` component; and,
- Updates the `README` in a few ways:
  - Fixes the casing of npm and adds a link to it;
  - Adds instructions for saving to `dependencies` in `package.json` via npm;
  - Adds instructions for installing via Yarn; and,
  - Fixes indentation of a closing paren in some example code.