### PR TITLE
Support for enter and exit animations

### DIFF
--- a/src/NotificationItem.jsx
+++ b/src/NotificationItem.jsx
@@ -48,7 +48,7 @@ var NotificationItem = React.createClass({
 
   getInitialState: function() {
     return {
-      visible: false,
+      visible: undefined,
       removed: false
     };
   },
@@ -250,7 +250,7 @@ var NotificationItem = React.createClass({
 
     if (this.state.visible) {
       className += ' notification-visible';
-    } else {
+    } else if (this.state.visible) {
       className += ' notification-hidden';
     }
 

--- a/src/NotificationItem.jsx
+++ b/src/NotificationItem.jsx
@@ -250,7 +250,7 @@ var NotificationItem = React.createClass({
 
     if (this.state.visible) {
       className += ' notification-visible';
-    } else if (!this.state.visible) {
+    } else if (this.state.visible === false) {
       className += ' notification-hidden';
     }
 

--- a/src/NotificationItem.jsx
+++ b/src/NotificationItem.jsx
@@ -250,7 +250,7 @@ var NotificationItem = React.createClass({
 
     if (this.state.visible) {
       className += ' notification-visible';
-    } else if (this.state.visible) {
+    } else if (!this.state.visible) {
       className += ' notification-hidden';
     }
 

--- a/test/notification-system.test.js
+++ b/test/notification-system.test.js
@@ -72,10 +72,18 @@ describe('Notification Component', function() {
     done();
   });
 
-  it('should set the notification class from hidden to visible after added', done => {
+  it('should not set a notification visibility class when the notification is initially added', done => {
     component.addNotification(defaultNotification);
     let notification = TestUtils.findRenderedDOMComponentWithClass(instance, 'notification');
-    expect(notification.className).toMatch(/notification-hidden/);
+    expect(notification.className).toNotMatch(/notification-hidden/);
+    expect(notification.className).toNotMatch(/notification-visible/);
+    done();
+  });
+
+  it('should set the notification class to visible after added', done => {
+    component.addNotification(defaultNotification);
+    let notification = TestUtils.findRenderedDOMComponentWithClass(instance, 'notification');
+    expect(notification.className).toMatch(/notification/);
     clock.tick(400);
     expect(notification.className).toMatch(/notification-visible/);
     done();


### PR DESCRIPTION
This adds support for enter and exit animations for NotificationItem.

Previously the initial class given to the NotificationItem component was `.notification-hidden` and immediately changed to `.notification-hidden` this causes the notifications to always have the same transition animation from `.notification-visible` to `.notification-hidden` and the other way but in reverse transition.

Now there's a difference between the initial state of the NotificationItem.
When `state.visible` is `undefined` it means that the NotificationItem is first rendered
When `state.visible` is `true` it means that the NotificationItem is transitioning to a visible state
When `state.visible` is `false` it means that the NotificationItem is transitioning to a hidden state

This fixes issue #83 
