### PR TITLE
fix: remove notification from state before calling onRemove

### DIFF
--- a/src/NotificationSystem.jsx
+++ b/src/NotificationSystem.jsx
@@ -70,12 +70,12 @@ var NotificationSystem = React.createClass({
       return toCheck.uid !== uid;
     });
 
-    if (notification && notification.onRemove) {
-      notification.onRemove(notification);
-    }
-
     if (this._isMounted) {
       this.setState({ notifications: notifications });
+    }
+
+    if (notification && notification.onRemove) {
+      notification.onRemove(notification);
     }
   },
 


### PR DESCRIPTION
Currently `onRemove` is called _before_ actually removing the notification from state, which means if you try to add a notification in your `onRemove` handler, any notifications that are added will be overridden when the function returns and `setState` is called with the stale notifications object.  This change would allow you to implement functionality to only show X amount of notifications at a time.

Moving the call to alter state _above_ the call to `onRemove` removes this side effect.