### PR TITLE
Add static accessor methods

### DIFF
--- a/src/NotificationSystem.jsx
+++ b/src/NotificationSystem.jsx
@@ -225,13 +225,21 @@ var NotificationSystem = createReactClass({
     });
   },
 
+
   componentDidMount: function() {
     this._getStyles.setOverrideStyle(this.props.style);
     this._isMounted = true;
+    if (NotificationSystem.instance) {
+      console.warn('NotificationSystem', 'Attempting to mount a second system into the DOM.');
+    }
+    NotificationSystem.instance = this;
   },
 
   componentWillUnmount: function() {
     this._isMounted = false;
+    if (NotificationSystem.instance === this) {
+      NotificationSystem.instance = null;
+    }
   },
 
   render: function() {
@@ -270,6 +278,40 @@ var NotificationSystem = createReactClass({
         { containers }
       </div>
     );
+  },
+
+  //These just proxy the current actively mounted instance.
+  statics: {
+    addNotification: function(notification) {
+      if (NotificationSystem.instance) {
+        return NotificationSystem.instance.addNotification(notification);
+      } else {
+        console.warn('NotificationSystem', 'No instance to add notification.', notification);
+        //return notification to prevent null pointer errors.
+        return notification;
+      }
+    },
+    removeNotification: function(notification) {
+      if (NotificationSystem.instance) {
+        return NotificationSystem.instance.remoteNotification(notification);
+      } else {
+        console.warn('NotificationSystem', 'No instance to remote notification.', notification);
+      }
+    },
+    editNotification: function(notification) {
+      if (NotificationSystem.instance) {
+        return NotificationSystem.instance.editNotification(notification);
+      } else {
+        console.warn('NotificationSystem', 'No instance to edit notification.', notification);
+      }
+    },
+    clearNotifications: function() {
+      if (NotificationSystem.instance) {
+        return NotificationSystem.instance.clearNotifications();
+      } else {
+        console.warn('NotificationSystem', 'No instance to clear notifications.');
+      }
+    }
   }
 });
 

--- a/src/NotificationSystem.jsx
+++ b/src/NotificationSystem.jsx
@@ -280,37 +280,36 @@ var NotificationSystem = createReactClass({
     );
   },
 
-  //These just proxy the current actively mounted instance.
+  // These just proxy the current actively mounted instance.
   statics: {
     addNotification: function(notification) {
       if (NotificationSystem.instance) {
         return NotificationSystem.instance.addNotification(notification);
-      } else {
-        console.warn('NotificationSystem', 'No instance to add notification.', notification);
-        //return notification to prevent null pointer errors.
-        return notification;
       }
+      console.warn('NotificationSystem', 'No instance to add notification.', notification);
+      // return notification to prevent null pointer errors.
+      return notification;
     },
     removeNotification: function(notification) {
       if (NotificationSystem.instance) {
         return NotificationSystem.instance.remoteNotification(notification);
-      } else {
-        console.warn('NotificationSystem', 'No instance to remote notification.', notification);
       }
+      console.warn('NotificationSystem', 'No instance to remote notification.', notification);
+      return notification;
     },
     editNotification: function(notification) {
       if (NotificationSystem.instance) {
         return NotificationSystem.instance.editNotification(notification);
-      } else {
-        console.warn('NotificationSystem', 'No instance to edit notification.', notification);
       }
+      console.warn('NotificationSystem', 'No instance to edit notification.', notification);
+      return notification;
     },
     clearNotifications: function() {
       if (NotificationSystem.instance) {
         return NotificationSystem.instance.clearNotifications();
-      } else {
-        console.warn('NotificationSystem', 'No instance to clear notifications.');
       }
+      console.warn('NotificationSystem', 'No instance to clear notifications.');
+      return null;
     }
   }
 });


### PR DESCRIPTION
Since an application typically only needs one instance of <NotificationSystem/> mounted to add rich notifications, it would make sense that the Notification API should be able to be statically accessed.  I know this can be done via the redux wrapper, but it would make sense to allow it outside of using redux (I don't use it, I like the theory, dislike the implementation).

When componentDidMount is called on the instance NotificationSystem.instance is assigned and componentWillUnmount removes the assignment.

For all the methods (NotificationSystem.addNotification, etc.) it just proxies the instance or throws a console warning if the system isn't mounted.

```javascript
import NotificationSystem from 'react-notification-system'

class MyRootApp extends Component {
    render() {
        return <div>
            ...
            <NotificationSystem/>
        </div>
    }
}

...later, no refs needed

NotificationSystem.addNotification({
    message: 'My Message',
    level: 'info'
})

```

None of the changes are breaking, it just adds the static methods.