### PR TITLE
dismiss button position style fix

### DIFF
--- a/src/styles.js
+++ b/src/styles.js
@@ -194,7 +194,8 @@ var STYLES = {
       width: '14px',
       height: '14px',
       fontWeight: 'bold',
-      textAlign: 'center'
+      textAlign: 'center',
+      lineHeight: '14px',
     },
 
     success: {


### PR DESCRIPTION
I've fixed style of position of content "dismiss" button, from this:
![image](https://user-images.githubusercontent.com/7108843/30038245-79a805e4-91d3-11e7-8d8b-ae3ec6e7ed73.png)

to this:
![image](https://user-images.githubusercontent.com/7108843/30038243-76254904-91d3-11e7-893c-3c3720928888.png)
