### PR TITLE
Upgrade to React v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
     "prop-types": "^15.5.6"
   },
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0",
-    "react-dom": "0.14.x || ^15.0.0"
+    "react": "0.14.x || ^15.0.0 || ^16.0.0",
+    "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",
@@ -72,9 +72,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.3.3",
     "node-sass": "^3.3.3",
-    "react": "^15.0.0",
-    "react-addons-test-utils": "^15.0.0",
-    "react-dom": "^15.0.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "react-tools": "^0.13.2",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",

--- a/test/notification-system.test.js
+++ b/test/notification-system.test.js
@@ -1,7 +1,7 @@
 /* global sinon */
 
 import React, { Component } from 'react';
-import TestUtils from 'react-addons-test-utils';
+import TestUtils from 'react-dom/test-utils';
 import expect from 'expect';
 import NotificationSystem from 'NotificationSystem';
 import { positions, levels } from 'constants';


### PR DESCRIPTION
- Fixes #123 
- React is upgraded to v16
- `TestUtils` are now in `react-dom` [(https://www.npmjs.com/package/react-addons-test-utils)](https://www.npmjs.com/package/react-addons-test-utils)