### PR TITLE
Added render props

### DIFF
--- a/src/NotificationSystem.jsx
+++ b/src/NotificationSystem.jsx
@@ -94,7 +94,8 @@ var NotificationSystem = createReactClass({
       PropTypes.object
     ]),
     noAnimation: PropTypes.bool,
-    allowHTML: PropTypes.bool
+    allowHTML: PropTypes.bool,
+    children: PropTypes.func
   },
 
   getDefaultProps: function() {
@@ -262,11 +263,18 @@ var NotificationSystem = createReactClass({
       });
     }
 
-
     return (
-      <div className="notifications-wrapper" style={ this._getStyles.wrapper() }>
-        { containers }
-      </div>
+      <React.Fragment>
+        <div className="notifications-wrapper" style={ this._getStyles.wrapper() }>
+          { containers }
+        </div>
+        {this.props.children && this.props.children({
+          addNotification: this.addNotification,
+          editNotification: this.editNotification,
+          removeNotification: this.removeNotification,
+          clearNotifications: this.clearNotifications
+        })}
+      </React.Fragment>
     );
   }
 });

--- a/test/notification-system.test.js
+++ b/test/notification-system.test.js
@@ -60,6 +60,18 @@ describe('Notification Component', function() {
     done();
   });
 
+  it('should pass renderprops', done => {
+    node = window.document.createElement('div');
+    instance = TestUtils.renderIntoDocument(React.createElement(
+      NotificationSystem, null, ({addNotification, editNotification, removeNotification, clearNotifications}) => {
+          expect(addNotification).to.not.be.null;
+          expect(editNotification).to.not.be.null;
+          expect(removeNotification).to.not.be.null;
+          expect(clearNotifications).to.not.be.null;
+        }), node);
+    done();
+  });
+
   it('should hold the component ref', done => {
     expect(component).to.not.be.null;
     done();


### PR DESCRIPTION
Allowing for render props. This should simplify a lot of the issues people have using refs.

Example usage:

```js
<NotificationSystem>
  {({ addNotification }) => (
    <button onClick={() => addNotification({ message: 'New notification' })}>Add Notification</button>
  )}
</NotificationSystem>
```