### PR TITLE
Update React and dependencies versions  to work with 17 or 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "prop-types": "^15.5.6"
   },
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0 || ^16.0.0",
-    "react-dom": "0.14.x || ^15.0.0 || ^16.0.0"
+    "react":">=16.0.0",
+    "react-dom":">=16.0.0"
   },
   "devDependencies": {
     "autoprefixer-loader": "^3.1.0",
@@ -70,8 +70,8 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^4.0.1",
     "node-sass": "^4.13.0",
-    "react": "^16.11.0",
-    "react-dom": "^16.11.0",
+    "react": ">=16.11.0",
+    "react-dom": ">=16.11.0",
     "react-tools": "^0.13.2",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",


### PR DESCRIPTION
- Updated React and React DOM dependencies to version 16.11.0 or higher.

Sorry, I left my old account, Oskku so here I've squashed all the changes into one commit. Additionally, I removed the 'create-react-class' dependency as it is not used in the latest versions.